### PR TITLE
hotfix(observations): enable using line_id or rno colummns as obsnames

### DIFF
--- a/sfrmaker/observations.py
+++ b/sfrmaker/observations.py
@@ -86,8 +86,17 @@ def add_observations(sfrdata, data, flowline_routing=None,
     reach_data = sfrdata.reach_data.copy()
 
     # allow input via a list of tables or single table
-    data = read_tables(data, dtype={obsname_column: object})
-    assert data[obsname_column].dtype == object
+    data = read_tables(data)#, dtype={obsname_column: object})
+    # need a special case if allowing obsname_column to also be identifier
+    if obsname_column == rno_column:
+        obsname_column = f'obsnamecol_{obsname_column}'
+        data[obsname_column] = data[rno_column].astype(object)
+    elif obsname_column == line_id_column:
+        obsname_column = f'obsnamecol_{obsname_column}'
+        data[obsname_column] = data[line_id_column].astype(object)
+    else:
+        data[obsname_column] = data[obsname_column].astype(object)
+    assert data[obsname_column].dtype == np.object
 
     # read reach geometries from a shapefile
     if sfrlines_shapefile is not None:

--- a/sfrmaker/test/test_observations.py
+++ b/sfrmaker/test/test_observations.py
@@ -104,8 +104,7 @@ def test_write_mf6_sfr_obsfile(shellmound_sfrdata, flux_observation_data, outdir
             if 'obs6' in line.lower():
                 _, _, fname = line.strip().split()
                 assert os.path.exists(os.path.join(outdir, fname))
-                break
-
+                break                                              
 
 def test_add_observations_from_line_ids(shellmound_sfrdata, flux_observation_data, outdir):
     obs = shellmound_sfrdata.add_observations(flux_observation_data,
@@ -134,6 +133,23 @@ def test_add_observations_from_line_ids(shellmound_sfrdata, flux_observation_dat
                                   check_dtype=False
                                   )
 
+    # test line_id and obsname same column
+    obs = shellmound_sfrdata.add_observations(flux_observation_data,
+                                              obstype='downstream-flow',
+                                              line_id_column='line_id',
+                                              obsname_column='line_id'
+                                              )
+    assert set(obs.obsname) == set([str(i) for i in flux_observation_data.line_id])
+
+    # test rno_column and obsname same column
+    obs = shellmound_sfrdata.add_observations(flux_observation_data,
+                                              obstype='downstream-flow',
+                                              rno_column='junk',
+                                              obsname_column='junk'
+                                              )
+    assert set(obs.obsname) == set([str(i) for i in flux_observation_data.junk])
+
+    
     # test assigning obs from custom reach number column?
     obs = shellmound_sfrdata.add_observations(flux_observation_data,
                                               obstype='downstream-flow',


### PR DESCRIPTION
There was an issue preventing the specification of `line_id_column` or `rno_column` as the `obsname_column` as well because the dataframe containing the `obsname_column` was being converted to `object` and, if it needed to still be numeric (e.g. line_id) then later the path dictionaries crashed. So, just flipping the info from those columns into a copy that is object. 
Tests included.